### PR TITLE
Don't try to splice array that was just set to null.

### DIFF
--- a/src/components/ReferenceData.vue
+++ b/src/components/ReferenceData.vue
@@ -239,8 +239,9 @@ export default {
 		removeValue(index) {
 			if (index === -1) {
 				this.selectedOptions = null
+			} else {
+				this.selectedOptions.splice(index, 1)
 			}
-			this.selectedOptions.splice(index, 1)
 		},
 		atSelect() {
 			if (this.async) {


### PR DESCRIPTION
Fix minor bug in ReferenceData component where in some cases we first set selectedOptions=null and then attempt to selectedOptions.splice().